### PR TITLE
update actions to all use Node.js 12

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout this repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Install Julia
               uses: julia-actions/setup-julia@v1
@@ -30,7 +30,7 @@ jobs:
 
             # We set up a folder that Pluto can use to cache exported notebooks. If the notebook file did not change, then Pluto can take the exported file from cache instead of running the notebook.
             - name: Set up notebook state cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: pluto_state_cache
                   key: ${{ runner.os }}-pluto_state_cache-v2-${{ hashFiles('**/Project.toml', '**/Manifest.toml', '.github/workflows/*' ) }}-${{ hashFiles('**/*jl') }}
@@ -57,8 +57,9 @@ jobs:
 
 
             - name: Deploy to gh-pages
-              uses: JamesIves/github-pages-deploy-action@releases/v3
+              uses: JamesIves/github-pages-deploy-action@releases/v4
               with:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  BRANCH: gh-pages
-                  FOLDER: .
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: gh-pages
+                  folder: .
+                  single-commit: true


### PR DESCRIPTION
These emitted a deprecation warning when the job ran. I also set the option to always squash the `gh-pages` branch down to one commit by default, since the Pluto state cache can get quite large, which can blow up the repo size. I can change that back though if we decide keeping the history of the `gh-pages` branch might be important.