### PR TITLE
Use `permissions` field in workflow to get write permission

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -11,6 +11,11 @@ concurrency:
     group: pluto-export
     cancel-in-progress: true
 
+# This action needs permission to write the exported HTML file to the gh-pages branch.
+permissions:
+    contents: write
+    # (all other permission fields default to "none")
+
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ You now have your own repository (take a look at the URL), containing a copy of 
 
 ### 👉 Step 2
 
-Go to the ["Settings" page](./settings) of your repository, and go to [the "Actions → General" section](./settings/actions). For the setting _**Workflow permissions**_, choose the option **Read and write permissions**, and click **Save**. (This will allow our Pluto *action* to *write* the exported HTML files to your website directory, more on this later.)
-
-<img width="400" alt="screenshot of clicking the Workflow permissions setting in the Actions settings page" src="https://user-images.githubusercontent.com/6933510/224754996-bf5745e6-c19f-40c2-85f5-0016dd8df2d6.png">
-
-### 👉 Step 2
-
-Go back to the **"Code" page** of your repository (where you are reading this text). Click on **Add files** (or **+**), and then **Upload files**. In the next page, upload your `.jl` notebook files.
+Click on **Add files** (or **+**), and then **Upload files**. In the next page, upload your `.jl` notebook files.
 
 <img width="400" alt="screenshot of clicking the Upload-files button" src="https://user-images.githubusercontent.com/6933510/103710071-67da4f00-4fb4-11eb-9943-b66f26119d36.png">
 


### PR DESCRIPTION
The recent issues #15 #17 were caused by a change in the default permissions: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

What I didn't realise, is that you can still use the `permissions` field to define `write` permission in the workflow: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

This means that we don't need to ask users to change their default permissions (#16), and our instructions are just 3 steps again! 🎉